### PR TITLE
Enable custom search

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,6 @@ These objects also have several optional attributes that can make the cells disp
 This is a boolean to tell the table whether or not show the search component
 ##### showPagination (default: false)
 This is a boolean to tell the table whether or not show the pagination component
-##### resetPagination (default: true)
-This is a boolean to tell the table whether or not reset the pagination when table properties change. This can be used when a new row is added to the table.
 ##### rowSize (default: 15)
 This is a number that tells the table how many rows it should display on a table.
 ##### currentPage (default: 1)
@@ -114,6 +112,14 @@ This function will receive:
   - Let the user specify the page they want to go to with onChange and it will pick up your value. example `<input onChange={ goToPage } />` 
   - Specify the exact page by giving it a newPage value. example `goToPage({ newPage: 25 })`
 - `inputtedPage`: The value to use for `goToPage` function if you are allowing a user to input a value. example `<input value={ inputtedPage } onChange={ goToPage } />`
+### CustomSort
+This is a function that you can pass to the table when you don't want to use the built in sort component. You will still need to have `showSort` set to true.
+
+This function will receive:
+- `searchString`: String to search for
+- `searchRows`: Search function that will be used for the search. This can be reused or extended as needed
+- `clearSearch`: Clear selection
+searchString, searchRows, clearSearch
 
 ##### icons
 This is an object that allows you to customize the ascending and decending icons on the columns and the open and close row icons on the rows

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-collapsing-table",
-  "version": "0.4.3",
+  "version": "0.4.2",
   "description": "react-collapsing-table: a React rewrite of the jQuery table plugin from 'datatables.net'. Inspired by a lack of similar table behaviors, notably collapsibility and responsivity.",
   "main": "build/index.js",
   "peerDependencies": {

--- a/src/__tests__/components/Table.test.js
+++ b/src/__tests__/components/Table.test.js
@@ -6,6 +6,7 @@ import * as searchActions from '../../actions/SearchActions';
 import * as resizeTableActions from '../../actions/ResizeTableActions';
 import * as tableActions from '../../actions/TableActions';
 import TextInputPagination from '../../../stories/TextInputPagination';
+import CustomSearch from '../../../stories/CustomSearch';
 
 //Testing
 import { mount, shallow, } from 'enzyme';
@@ -98,6 +99,14 @@ describe('Table', () => {
         const paginations = wrapper.find('TextInputPagination');
 
         expect(paginations.length).toBe(1);
+    });
+
+    it('should render a Custom Search component', () => {
+        props = { ...props, showSearch: true, CustomSearch: CustomSearch };
+        wrapper = shallow(<Table { ...props }/>);
+        const searchs = wrapper.find('CustomSearch');
+
+        expect(searchs.length).toBe(1);
     });
 
     it('should render correctly with no rows', () => {

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -34,6 +34,7 @@ export class Table extends Component {
             paginationEventListener = null,
             totalPages = (rows.length === 0) ? 1 : Math.ceil(rows.length / rowSize),
             CustomPagination = null,
+            CustomSearch = null,
             icons = null,
             id = null,
             theme = 'react-collapsible-theme'
@@ -61,6 +62,7 @@ export class Table extends Component {
             resetPagination,
             paginationEventListener,
             CustomPagination,
+            CustomSearch,
             icons,
             id,
             theme,
@@ -161,6 +163,7 @@ export class Table extends Component {
             showSearch,
             showPagination,
             CustomPagination,
+            CustomSearch,
             icons,
             id,
             theme,
@@ -183,9 +186,14 @@ export class Table extends Component {
                               previousPage={ this.previousPage } />
                 : null;
 
-        const SearchComponent = showSearch && <Search searchString={ this.state.searchString }
-                                                      searchRows={ this.searchRows }
-                                                      clearSearch={ this.clearSearch } />;
+        const SearchElement = CustomSearch || Search;
+        const SearchComponent = showSearch ? 
+            <SearchElement 
+                searchString={ this.state.searchString }
+                searchRows={ this.searchRows } 
+                clearSearch={ this.clearSearch }
+            /> :
+            null;
 
         return (
             <div className={theme}>

--- a/stories/CustomSearch.js
+++ b/stories/CustomSearch.js
@@ -1,16 +1,14 @@
 //React
 import React from 'react';
-import { SearchPropType } from '../utils/propTypes'
 
-const Search = ({ searchString, searchRows, clearSearch }) => {
+const CustomSearch = ({ searchString, searchRows, clearSearch }) => {
     return (
         <div className="react-collapsible-search">
+            <h2>Custom search</h2>
             <input onChange={ searchRows } value={ searchString } placeholder="search"/>
             <button className="react-collapsible-clear" onClick={ clearSearch }>&#9587;</button>
         </div>
     );
 };
 
-Search.propTypes = SearchPropType;
-
-export default Search
+export default CustomSearch

--- a/stories/index.js
+++ b/stories/index.js
@@ -13,6 +13,7 @@ import {
     paginationListenerProps,
     sortableColumnsProps,
     customPaginationComponent,
+    customSortComponent,
     customIconProps,
     differentTheme,
     unsorted,
@@ -28,6 +29,7 @@ storiesOf('React Collapsing Table', module)
     .add('Set a pagination listener function', () => <ReactCollapsingTable {...paginationListenerProps} />)
     .add('Only certain columns can be sorted on', () => <ReactCollapsingTable {...sortableColumnsProps} />)
     .add('Custom Text Input Pagination', () => <ReactCollapsingTable {...customPaginationComponent} />)
+    .add('Custom Sort', () => <ReactCollapsingTable {...customSortComponent} />)
     .add('Custom Icons for the open/close row and de/ascending icon', () => <ReactCollapsingTable {...customIconProps} />)
     .add('Columns with sort feature disabled', () => <ReactCollapsingTable {...unsorted} />)
     .add('Custom theme, no applied styles', () => <ReactCollapsingTable {...differentTheme} />);

--- a/stories/props.js
+++ b/stories/props.js
@@ -4,6 +4,7 @@ import moment from 'moment';
 import Button from './button';
 import Link from './link';
 import TextInputPagination from './TextInputPagination';
+import CustomSearch from './CustomSearch';
 import ArrowUp from 'react-icons/lib/fa/arrow-up';
 import ArrowDown from 'react-icons/lib/fa/arrow-down';
 
@@ -131,6 +132,13 @@ export const customPaginationComponent = {
     showPagination: true,
     showSearch: true,
     CustomPagination: TextInputPagination,
+};
+
+export const customSortComponent = {
+    columns: getColumns(),
+    rows: generateFakeData({ totalRows: 1000 }),
+    showSearch: true,
+    CustomSearch: CustomSearch,
 };
 
 export const customIconProps = {


### PR DESCRIPTION
This PR enables custom search to be passed as a prop. This feature is similar to passing a custom pagination component.

### Usage

```js
// CustomSearch.js
import React from 'react';
import { SearchPropType } from '../utils/propTypes'

const CustomSearch = ({ searchString, searchRows, clearSearch }) => {
    return (
        <div className="react-collapsible-search">
            <input onChange={ searchRows } value={ searchString } placeholder="search"/>
            <button className="react-collapsible-clear" onClick={ clearSearch }>&#9587;</button>
        </div>
    );
};

export default CustomSearch
```

```js
// table.js
import CustomSearch from './CustomSearch'
import Table from '../table'

<Table showSearch={true}, CustomSearch={CustomSearch} />
```